### PR TITLE
Fix

### DIFF
--- a/multiple_inheritance/generic_class_solution.cpp
+++ b/multiple_inheritance/generic_class_solution.cpp
@@ -63,14 +63,18 @@ public:
 
     Interface* clone() const override {
         std::cout << "Interface* BBase::clone" << std::endl;
-        return nullptr;
+		if constexpr(std::is_abstract<BBase>::value) {
+			throw std::runtime_error("BBase is abstract");
+		} else {
+			return new BBase(*this);
+		}
     }
 };
 
 using BImpl = BBase<B>;
 
 template <typename Interface>
-class CBase : public ABase<C> {
+class CBase : public ABase<Interface> {
 public:
     void do_c() override {
         std::cout << "CBase::do_c" << std::endl;
@@ -82,7 +86,11 @@ public:
 
     Interface* clone() const override {
         std::cout << "Interface* CBase::clone" << std::endl;
-        return nullptr;
+		if constexpr(std::is_abstract<CBase>::value) {
+			throw std::runtime_error("CBase is abstract");
+		} else {
+			return new CBase(*this);
+		}
     }
 };
 
@@ -98,7 +106,7 @@ public:
 
     D* clone() const override {
         std::cout << "D* DImpl::clone" << std::endl;
-        return nullptr;
+        return new DImpl(*this);
     }
 };
 
@@ -125,7 +133,7 @@ public:
 
     BC* clone() const override {
         std::cout << "BC* BCImpl::clone" << std::endl;
-        return nullptr;
+        return new BCImpl(*this);
     }
 };
 
@@ -140,7 +148,7 @@ void testConcreteImpl() {
     test.do_a();
     test.do_b();
     test.do_b_private();
-    std::cout << typeid(test.clone()).name() << " expected B*" << std::endl;
+    std::cout << typeid(*test.clone()).name() << " expected B" << std::endl;
 }
 
 void testExtendingConcreteImpl() {
@@ -176,7 +184,7 @@ void testMultipleInheritanceUpCast() {
     std::cout << "\n*** Multiple Inheritance Up Cast Test ***\n" << std::endl;
     BCImpl test;
     auto interface = static_multi_cast<B, BCImpl::B>(&test);
-    std::cout << typeid(interface->clone()).name() << " expected BC*" << std::endl;
+    std::cout << typeid(*interface->clone()).name() << " expected BCImpl" << std::endl;
 }
 
 void testMultipleInheritanceDownCast() {
@@ -184,7 +192,7 @@ void testMultipleInheritanceDownCast() {
     BCImpl test;
     auto b_interface = static_multi_cast<B, BCImpl::B>(&test);
     auto bc_interface = static_cast<BC*>(b_interface);
-    std::cout << typeid(bc_interface->clone()).name() << " expected BC*" << std::endl;
+    std::cout << typeid(*bc_interface->clone()).name() << " expected BCImpl" << std::endl;
 }
 
 int main() {

--- a/multiple_inheritance/generic_class_solution.cpp
+++ b/multiple_inheritance/generic_class_solution.cpp
@@ -10,14 +10,14 @@ public:
     virtual A* clone() const = 0;
 };
 
-class B : public A {
+class B : public virtual A {
 public:
     virtual void do_b() = 0;
 
     virtual B* clone() const = 0;
 };
 
-class C : public A {
+class C : public virtual A {
 public:
     virtual void do_c() = 0;
 
@@ -51,7 +51,7 @@ public:
 using AImpl = ABase<A>;
 
 template <typename Interface>
-class BBase : public ABase<Interface> {
+class BBase : public virtual ABase<Interface> {
 public:
     void do_b() override {
         std::cout << "BBase::do_b" << std::endl;
@@ -74,7 +74,7 @@ public:
 using BImpl = BBase<B>;
 
 template <typename Interface>
-class CBase : public ABase<Interface> {
+class CBase : public virtual ABase<Interface> {
 public:
     void do_c() override {
         std::cout << "CBase::do_c" << std::endl;
@@ -166,9 +166,11 @@ void testCasts() {
     DImpl test;
     auto interface = static_cast<B*>(&test);
     std::cout << typeid(interface->clone()).name() << " expected D*" << std::endl;
-    auto impl = static_cast<BImpl*>(interface);
-    impl->do_b_private();
-    std::cout << typeid(impl->clone()).name() << " expected D*" << std::endl;
+
+    // IMPOSSIBLE because BBase inherits virtually from ABase<B> and thus B
+    // auto impl = static_cast<BImpl*>(interface);
+    // impl->do_b_private();
+    // std::cout << typeid(impl->clone()).name() << " expected D*" << std::endl;
 }
 
 void testMultipleInheritance() {


### PR DESCRIPTION
The problem wasn't with casting, but implementing the clone methods in BBase and CBase. Because these classes become abstract when Interface declares pure virtual methods that they don't know about. Can be fixed with constexpr if, but a better approach IMHO would be not to inherit from leaf classes.

Inorder to have the diamond in the Impl classes, virtual inheritance would be needed, which makes static down casts impossible.